### PR TITLE
Fix: sanitize hostnames with multiple dots

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ class Client {
         }
         namespace = namespace.replace(/^\.+/, '');
         const vars = {
-            hostname: hostname().replace('.', '_'),
+            hostname: hostname().replace(/\./g, '_'),
             pid: process.pid,
         };
         this.host = host instanceof URL ? host : new URL(host);

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -209,11 +209,11 @@ test.serial('hostname with dots substitution', (t) => {
     const host = new URL(`udp://127.0.0.1:${t.context.address.port}`);
     const namespace = 'ns1.${hostname}';
     const hostname = sinon.stub(os, 'hostname');
-    hostname.onCall(0).returns('some.host');
+    hostname.onCall(0).returns('some.nice.host');
     const client = new Client({ host, namespace });
     return new Promise<number>((resolve) => {
         t.context.server.on('metric', (metric) => {
-            t.is(`ns1.some_host.some.metric:1|s`, metric.toString());
+            t.is(`ns1.some_nice_host.some.metric:1|s`, metric.toString());
             hostname.restore();
             return resolve(0);
         });


### PR DESCRIPTION
## 🚨 Proposed changes

Currently it only replace the first occurrence of dot in the hostname and this leads to multiple metrics for hostname with multiple dots.

Example:
```
const hostname = 'ws-node01.my.nice.domain';
> hostname.replace('.','_')
'ws-node01_my_nice_domain'
```

Cannot use `String.replaceAll()` because introduced in ECMAScript 2021 version so i changed the regex.

## ⚙️ Types of changes

-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor
