### PR TITLE
feat(client): Add support for tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ This module exports:
     -   `udpDnsCacheTTL`: Optional. Default `120`. Dns cache Time to live in seconds.
     -   `onError`: Optional. Default `(err) => void`. Called when there is an error. Allows you to check also send errors.
     -   `customSocket`: Optional. Default `null`. Custom socket used by the client, this is a feature for mocking we do not recommend using it in production.
+    -   `tags`: Optional Default `null`. If provided, metrics will include tags in the form `#key1:value1,key2:value2`.
 
 #### `Client.close([cb])`
 
@@ -328,5 +329,5 @@ If you have any questions on how to use dats, bugs and enhancement please feel f
 
 ## License
 
-dats is licensed under the MIT license.  
+dats is licensed under the MIT license.
 See the [LICENSE](./LICENSE) file for more information.

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ class Client {
     protected namespace: string;
     protected debug: DebugLogger;
     protected isDebug: boolean;
-    protected tags: Tags;
+    protected tags: string;
 
     constructor({
         host,
@@ -127,7 +127,15 @@ class Client {
         this.bufferFlushTimeout = bufferFlushTimeout;
         this.timeout = null;
         this.timeoutActive = false;
-        this.tags = tags;
+        if (tags) {
+            if (Array.isArray(tags)) {
+                this.tags = tags.join(',');
+            } else {
+                this.tags = Object.keys(tags)
+                    .map((tag) => `${tag}:${tags[tag]}`)
+                    .join(',');
+            }
+        }
     }
 
     connect(): Promise<boolean> {
@@ -151,14 +159,7 @@ class Client {
         }
 
         if (this.tags) {
-            if (Array.isArray(this.tags)) {
-                metric += `|#${this.tags.join(',')}`;
-            } else {
-                const tags = Object.keys(this.tags)
-                    .map((tag) => `${tag}:${this.tags[tag]}`)
-                    .join(',');
-                metric += `|#${tags}`;
-            }
+            metric += `|#${this.tags}`;
         }
 
         return metric;

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export enum Types {
 
 Object.freeze(Types);
 
-export type Tags = { [key: string]: string } | string[];
+export type Tags = { [key: string]: string | null } | string[];
 
 export interface Options {
     host?: string | URL;
@@ -132,7 +132,7 @@ class Client {
                 this.tags = tags.join(',');
             } else {
                 this.tags = Object.keys(tags)
-                    .map((tag) => `${tag}:${tags[tag]}`)
+                    .map((tag) => (tags[tag] ? `${tag}:${tags[tag]}` : tag))
                     .join(',');
             }
         }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -111,6 +111,20 @@ test('counter with sampling', (t) => {
     });
 });
 
+test('counter with tags', (t) => {
+    const host = new URL(`udp://127.0.0.1:${t.context.address.port}`);
+    const namespace = 'ns1';
+    const tags = { tag1: 'value1', tag2: 'value2' };
+    const client = new Client({ host, namespace, tags });
+    return new Promise<number>((resolve) => {
+        t.context.server.on('metric', (metric) => {
+            t.is(`${namespace}.some.metric:1|c|@10|#tag1:value1,tag2:value2`, metric.toString());
+            return resolve(0);
+        });
+        client.counter('some.metric', 1, 10);
+    });
+});
+
 test('timing', (t) => {
     const host = new URL(`udp://127.0.0.1:${t.context.address.port}`);
     const namespace = 'ns1';
@@ -131,6 +145,20 @@ test('timing with sampling', (t) => {
     return new Promise<number>((resolve) => {
         t.context.server.on('metric', (metric) => {
             t.is(`${namespace}.some.metric:1|ms|@10`, metric.toString());
+            return resolve(0);
+        });
+        client.timing('some.metric', 1, 10);
+    });
+});
+
+test('timing with tags', (t) => {
+    const host = new URL(`udp://127.0.0.1:${t.context.address.port}`);
+    const namespace = 'ns1';
+    const tags = { tag1: 'value1', tag2: 'value2' };
+    const client = new Client({ host, namespace, tags });
+    return new Promise<number>((resolve) => {
+        t.context.server.on('metric', (metric) => {
+            t.is(`${namespace}.some.metric:1|ms|@10|#tag1:value1,tag2:value2`, metric.toString());
             return resolve(0);
         });
         client.timing('some.metric', 1, 10);
@@ -163,6 +191,20 @@ test('gauge should ignore sampling', (t) => {
     });
 });
 
+test('gauge with tags', (t) => {
+    const host = new URL(`udp://127.0.0.1:${t.context.address.port}`);
+    const namespace = 'ns1';
+    const tags = { tag1: 'value1', tag2: 'value2' };
+    const client = new Client({ host, namespace, tags });
+    return new Promise<number>((resolve) => {
+        t.context.server.on('metric', (metric) => {
+            t.is(`${namespace}.some.metric:1|g|#tag1:value1,tag2:value2`, metric.toString());
+            return resolve(0);
+        });
+        client.gauge('some.metric', 1);
+    });
+});
+
 test('set', (t) => {
     const host = new URL(`udp://127.0.0.1:${t.context.address.port}`);
     const namespace = 'ns1';
@@ -183,6 +225,20 @@ test('set should ignore sampling', (t) => {
     return new Promise<number>((resolve) => {
         t.context.server.on('metric', (metric) => {
             t.is(`${namespace}.some.metric:1|s`, metric.toString());
+            return resolve(0);
+        });
+        client.set('some.metric', 1);
+    });
+});
+
+test('set with tags', (t) => {
+    const host = new URL(`udp://127.0.0.1:${t.context.address.port}`);
+    const namespace = 'ns1';
+    const tags = { tag1: 'value1', tag2: 'value2' };
+    const client = new Client({ host, namespace, tags });
+    return new Promise<number>((resolve) => {
+        t.context.server.on('metric', (metric) => {
+            t.is(`${namespace}.some.metric:1|s|#tag1:value1,tag2:value2`, metric.toString());
             return resolve(0);
         });
         client.set('some.metric', 1);

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -114,11 +114,14 @@ test('counter with sampling', (t) => {
 test('counter with tags', (t) => {
     const host = new URL(`udp://127.0.0.1:${t.context.address.port}`);
     const namespace = 'ns1';
-    const tags = { tag1: 'value1', tag2: 'value2' };
+    const tags = { tag1: 'value1', tag2: null, tag3: 'value3' };
     const client = new Client({ host, namespace, tags });
     return new Promise<number>((resolve) => {
         t.context.server.on('metric', (metric) => {
-            t.is(`${namespace}.some.metric:1|c|@10|#tag1:value1,tag2:value2`, metric.toString());
+            t.is(
+                `${namespace}.some.metric:1|c|@10|#tag1:value1,tag2,tag3:value3`,
+                metric.toString()
+            );
             return resolve(0);
         });
         client.counter('some.metric', 1, 10);
@@ -154,11 +157,14 @@ test('timing with sampling', (t) => {
 test('timing with tags', (t) => {
     const host = new URL(`udp://127.0.0.1:${t.context.address.port}`);
     const namespace = 'ns1';
-    const tags = { tag1: 'value1', tag2: 'value2' };
+    const tags = { tag1: 'value1', tag2: null, tag3: 'value3' };
     const client = new Client({ host, namespace, tags });
     return new Promise<number>((resolve) => {
         t.context.server.on('metric', (metric) => {
-            t.is(`${namespace}.some.metric:1|ms|@10|#tag1:value1,tag2:value2`, metric.toString());
+            t.is(
+                `${namespace}.some.metric:1|ms|@10|#tag1:value1,tag2,tag3:value3`,
+                metric.toString()
+            );
             return resolve(0);
         });
         client.timing('some.metric', 1, 10);
@@ -194,11 +200,14 @@ test('gauge should ignore sampling', (t) => {
 test('gauge with tags', (t) => {
     const host = new URL(`udp://127.0.0.1:${t.context.address.port}`);
     const namespace = 'ns1';
-    const tags = { tag1: 'value1', tag2: 'value2' };
+    const tags = { tag1: 'value1', tag2: null, tag3: 'value3' };
     const client = new Client({ host, namespace, tags });
     return new Promise<number>((resolve) => {
         t.context.server.on('metric', (metric) => {
-            t.is(`${namespace}.some.metric:1|g|#tag1:value1,tag2:value2`, metric.toString());
+            t.is(
+                `${namespace}.some.metric:1|g|#tag1:value1,tag2,tag3:value3`,
+                metric.toString()
+            );
             return resolve(0);
         });
         client.gauge('some.metric', 1);
@@ -234,11 +243,14 @@ test('set should ignore sampling', (t) => {
 test('set with tags', (t) => {
     const host = new URL(`udp://127.0.0.1:${t.context.address.port}`);
     const namespace = 'ns1';
-    const tags = { tag1: 'value1', tag2: 'value2' };
+    const tags = { tag1: 'value1', tag2: null, tag3: 'value3' };
     const client = new Client({ host, namespace, tags });
     return new Promise<number>((resolve) => {
         t.context.server.on('metric', (metric) => {
-            t.is(`${namespace}.some.metric:1|s|#tag1:value1,tag2:value2`, metric.toString());
+            t.is(
+                `${namespace}.some.metric:1|s|#tag1:value1,tag2,tag3:value3`,
+                metric.toString()
+            );
             return resolve(0);
         });
         client.set('some.metric', 1);


### PR DESCRIPTION
This change adds support for tagging metrics. This is helpful when there are multiple instances of the service running in the cloud, eg. for tagging based on availability zone, region, version, etc.

Tags are not part of the StatsD protocol, but are generally accepted by StatsD servers in the following form: `<metric>|#key1:value1,key2,value2`. For further examples, see Datadog's [DogStatsD protocol](https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics) and [NewRelic's metric format](https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/statsd/statsd-monitoring-integration/#metric-format).

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor
