### PR TITLE
fix: ensure udp messages are sent on close

### DIFF
--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -402,7 +402,7 @@ test('close with queued messages should wait', async (t) => {
     const host = new URL(`udp://127.0.0.1:${t.context.address.port}`);
     const namespace = 'ns1.${hostname}.${pid}';
     const client = new Client({ host, namespace });
-    t.plan(5);
+    t.plan(6);
     client.connect();
     client.counter('some');
     client.counter('some');
@@ -411,13 +411,12 @@ test('close with queued messages should wait', async (t) => {
     //@ts-expect-error Just for tests
     t.is(client.socket.pendingMessages, 4);
     //@ts-expect-error Just for tests
-    client.socket.once('idle', () => {
-        //@ts-expect-error Just for tests
-        t.is(client.socket.pendingMessages, 0);
-    });
+    const emit = sinon.spy(client.socket, 'emit');
     await t.notThrowsAsync(client.close() as Promise<void>);
     //@ts-expect-error Just for tests
     t.is(client.socket.pendingMessages, 0);
+    t.notThrows(() => client.timing('time', 1));
+    t.true(emit.calledOnceWith('idle'));
     t.pass();
 });
 


### PR DESCRIPTION
## 🚨 Proposed changes

> Please review the [guidelines for contributing](../../CONTRIBUTING.md) to this repository.

[[Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.]]

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced message handling now ensures all communications finish processing before disconnecting, providing a more reliable experience.
  - Added new properties to track pending messages and idle state in the socket classes.

- **Tests**
  - Introduced new testing scenarios to confirm that queued messages are correctly handled before a disconnection.
  - Added tests to verify the behavior of `SocketTcp` during the closing process, ensuring proper management of message queue and idle state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->